### PR TITLE
fix(#35; App): Improves details screen

### DIFF
--- a/app/src/main/java/br/com/rstudio/countries/arch/extension/ActivityExtensions.kt
+++ b/app/src/main/java/br/com/rstudio/countries/arch/extension/ActivityExtensions.kt
@@ -30,3 +30,7 @@ fun FragmentActivity?.replaceFragment(fragment: Fragment) = this?.run {
     .addToBackStack(fragment.TAG)
     .commit()
 }
+
+fun FragmentActivity?.popBackStack() = this?.run {
+  supportFragmentManager.popBackStack()
+}

--- a/app/src/main/java/br/com/rstudio/countries/presentation/details/screen/DetailsContract.kt
+++ b/app/src/main/java/br/com/rstudio/countries/presentation/details/screen/DetailsContract.kt
@@ -5,7 +5,9 @@ import br.com.rstudio.countries.data.model.Country
 interface DetailsContract {
 
   interface View {
+    fun clearViewContent()
     fun bindCountry(country: Country, countryBorders: List<String>? = null)
+    fun finish()
   }
 
   interface Presenter {

--- a/app/src/main/java/br/com/rstudio/countries/presentation/details/screen/DetailsFragment.kt
+++ b/app/src/main/java/br/com/rstudio/countries/presentation/details/screen/DetailsFragment.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.widget.LinearLayoutCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import br.com.rstudio.countries.R
+import br.com.rstudio.countries.arch.extension.popBackStack
 import br.com.rstudio.countries.arch.extension.setupBackPressedCallback
 import br.com.rstudio.countries.arch.widget.LoadImageView
 import br.com.rstudio.countries.data.model.Country
@@ -57,6 +58,10 @@ class DetailsFragment : Fragment(R.layout.fragment_details), DetailsContract.Vie
     presenter.onResume()
   }
 
+  override fun clearViewContent() {
+    containerView.removeAllViews()
+  }
+
   override fun bindCountry(country: Country, countryBorders: List<String>?) {
     bindCountryImage(country)
     bindName(country.name)
@@ -104,6 +109,10 @@ class DetailsFragment : Fragment(R.layout.fragment_details), DetailsContract.Vie
     }.also {
       containerView.addView(it)
     }
+  }
+
+  override fun finish() {
+    activity.popBackStack()
   }
 
   override fun onDestroy() {

--- a/app/src/main/java/br/com/rstudio/countries/presentation/details/screen/DetailsPresenter.kt
+++ b/app/src/main/java/br/com/rstudio/countries/presentation/details/screen/DetailsPresenter.kt
@@ -18,6 +18,7 @@ class DetailsPresenter(
       "${it.name}   ${it.littleFlag}"
     }
 
+    view?.clearViewContent()
     view?.bindCountry(country, bordersList)
   }
 
@@ -27,6 +28,7 @@ class DetailsPresenter(
 
   override fun onBackPressed() {
     tracker.trackBackPressed()
+    view?.finish()
   }
 
   override fun onDestroy() {

--- a/app/src/test/java/br/com/rstudio/countries/presentation/details/screen/DetailsPresenterTest.kt
+++ b/app/src/test/java/br/com/rstudio/countries/presentation/details/screen/DetailsPresenterTest.kt
@@ -2,6 +2,7 @@ package br.com.rstudio.countries.presentation.details.screen
 
 import br.com.rstudio.countries.data.model.Country
 import br.com.rstudio.countries.presentation.CountryModel.countryList
+import io.mockk.Ordering
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert
@@ -30,7 +31,10 @@ class DetailsPresenterTest {
   fun `when presenter initialize with null borders then should call view`() {
     presenter.onInitializer(country = mockk(), borders = null)
 
-    verify(exactly = 1) { view.bindCountry(any(), null) }
+    verify(exactly = 1) {
+      view.clearViewContent()
+      view.bindCountry(any(), null)
+    }
   }
 
   @Test
@@ -38,10 +42,21 @@ class DetailsPresenterTest {
     presenter.onInitializer(country = mockk(), borders = countryList)
 
     verify(exactly = 1) {
+      view.clearViewContent()
       view.bindCountry(
         any(),
         listOf("Country 1   litter flag 1", "Country 2   litter flag 2", "Country 3   litter flag 3")
       )
+    }
+  }
+
+  @Test
+  fun `when presenter initializes then it should clear view contents before binding`() {
+    presenter.onInitializer(country = mockk(), borders = null)
+
+    verify(ordering = Ordering.ORDERED) {
+      view.clearViewContent()
+      view.bindCountry(any(), null)
     }
   }
 
@@ -58,10 +73,13 @@ class DetailsPresenterTest {
   }
 
   @Test
-  fun `when onBackPressed is called then it should track it`() {
+  fun `when onBackPressed is called then it should finish view and track it`() {
     presenter.onBackPressed()
 
-    verify { tracker.trackBackPressed() }
+    verify {
+      tracker.trackBackPressed()
+      view.finish()
+    }
   }
 
   @Test


### PR DESCRIPTION
This pr fixes two bugs.
- Duplicate content on details screen when user exits and returns to the app
- Poor work when user clicks back button