### PR TITLE
fix(#45, App): Fix Jacoco coverage report

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,7 @@ android {
 
     buildTypes {
         debug {
+            FirebasePerformance.instrumentationEnabled = false
             versionNameSuffix '-debug'
 
             firebaseAppDistribution.artifactPath = "$buildDir/outputs/apk/debug/app-debug.apk"


### PR DESCRIPTION
This PR disables firebase performance in debug build. This workaround fixes Jacoco coverage report, but the real solution is upgrade to AGP 8.

References:
https://github.com/firebase/firebase-android-sdk/issues/3948