### PR TITLE
fix(#68; Integration): Define java version on github workflow

### DIFF
--- a/.github/workflows/build-application.yml
+++ b/.github/workflows/build-application.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'zulu'
+
       - name: Handle keystore
         if: ${{ inputs.environment == 'Release' }} || ${{ inputs.environment == 'Homolog' }}
         run: |
@@ -64,6 +70,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'zulu'
+
       - name: Run Detekt
         run: ./gradlew detekt
 
@@ -79,6 +91,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'zulu'
 
       - name: Run unit tests
         run: ./gradlew testDebugUnitTestCoverage
@@ -100,6 +118,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'zulu'
 
       - name: Download Apk
         uses: actions/download-artifact@v4

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -15,6 +15,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'zulu'
+
       - name: Run build
         run: ./gradlew assembleDebug
 
@@ -23,6 +29,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'zulu'
 
       - name: Run Detekt
         run: ./gradlew detekt
@@ -39,6 +51,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'zulu'
 
       - name: Run unit tests
         run: ./gradlew testDebugUnitTestCoverage


### PR DESCRIPTION
This PR sets up a specific Java version in the CI/CD pipeline. Without this configuration, the workflow uses the default Java environment provided by `ubuntu-latest`.