### PR TITLE
chore(#79; App): Migrate to kotlin parcelize.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ import java.nio.file.Paths
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
-    id 'kotlin-android-extensions'
+    id 'kotlin-parcelize'
     id 'io.gitlab.arturbosch.detekt'
     id 'com.google.gms.google-services'
     id 'com.google.firebase.crashlytics'

--- a/app/src/main/java/br/com/rstudio/countries/data/model/Country.kt
+++ b/app/src/main/java/br/com/rstudio/countries/data/model/Country.kt
@@ -1,7 +1,7 @@
 package br.com.rstudio.countries.data.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 class Country(

--- a/app/src/main/java/br/com/rstudio/countries/data/model/Quiz.kt
+++ b/app/src/main/java/br/com/rstudio/countries/data/model/Quiz.kt
@@ -1,7 +1,7 @@
 package br.com.rstudio.countries.data.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 class Quiz(


### PR DESCRIPTION
This PR removes the deprecated `kotlin-android-extensions` plugin and replaces it with `kotlin-parcelize`.